### PR TITLE
Fix breaking changes for parse-server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+node_js:
+  - "4.3"
+after_success: ./node_modules/.bin/codecov

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parse-server-azure-storage",
-  "version": "0.3.0",
+  "version": "1.0.0",
   "description": "Use Azure Blob Storage with Parse Server",
   "main": "lib/AzureStorageAdapter.js",
   "repository": {
@@ -21,12 +21,17 @@
   "devDependencies": {
     "babel-cli": "^6.5.1",
     "babel-core": "^6.5.1",
+    "babel-istanbul": "^0.7.0",
     "babel-preset-es2015": "^6.5.0",
     "babel-preset-stage-0": "^6.5.0",
-    "babel-register": "^6.5.1"
+    "babel-register": "^6.5.1",
+    "codecov": "^1.0.1",
+    "jasmine": "^2.4.1",
+    "parse-server-conformance-tests": "^1.0.0"
   },
   "scripts": {
-    "build": "./node_modules/.bin/babel src/ -d lib/"
+    "build": "./node_modules/.bin/babel src/ -d lib/",
+    "test": "./node_modules/.bin/babel-node ./node_modules/babel-istanbul/lib/cli.js cover -x **/spec/** ./node_modules/jasmine/bin/jasmine.js"
   },
   "engines": {
     "node": ">=4.3"

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -1,0 +1,6 @@
+{
+  "spec_dir": "spec",
+  "spec_files": [
+    "test.spec.js"
+  ]
+}

--- a/spec/test.spec.js
+++ b/spec/test.spec.js
@@ -1,0 +1,31 @@
+'use strict';
+let filesAdapterTests = require('parse-server-conformance-tests').files;
+
+let AzureStorageAdapter = require('../src/AzureStorageAdapter.js').default;
+
+describe('Azure tests', () => {
+
+  it('should throw when not initialized properly', () => {
+    expect(() => {
+      new AzureStorageAdapter();
+    }).toThrow('AzureStorageAdapter requires an account name');
+
+    expect(() => {
+      new AzureStorageAdapter('accountName');
+    }).toThrow('AzureStorageAdapter requires a container');
+  });
+
+  it('should not throw when initialized properly', () => {
+    expect(() => {
+      new AzureStorageAdapter('accountName', 'container', {'accessKey': new Buffer('accessKey').toString('base64') });
+    }).not.toThrow();
+  });
+
+  if (process.env.AZURE_ACCOUNT_NAME && process.env.AZURE_CONTAINER && process.env.AZURE_ACCESS_KEY) {
+    // Should be initialized from the env
+    let adapter = new AzureStorageAdapter(process.env.AZURE_ACCOUNT_NAME, process.env.AZURE_CONTAINER, {
+      accessKey: process.env.AZURE_ACCESS_KEY
+    });
+    filesAdapterTests.testAdapter("AzureAdapter", adapter);
+  }
+})

--- a/src/AzureStorageAdapter.js
+++ b/src/AzureStorageAdapter.js
@@ -29,7 +29,7 @@ export class AzureStorageAdapter {
    * @param  {string} data
    * @return {Promise} Promise containing the Azure Blob Storage blob creation response
    */
-  createFile(config, filename, data) {
+  createFile(filename, data) {
     let containerParams = {
       publicAccessLevel: (this._directAccess) ? 'blob' : undefined
     };
@@ -57,7 +57,7 @@ export class AzureStorageAdapter {
    * @param  {string} filename
    * @return {Promise} Promise that succeeds with the result from Azure Storage
    */
-  deleteFile(config, filename) {
+  deleteFile(filename) {
     return new Promise((resolve, reject) => {
       this._client.deleteBlob(this._container, filename, (err, res) => {
           if (err) {
@@ -75,7 +75,7 @@ export class AzureStorageAdapter {
    * @param  {string} filename
    * @return {Promise} Promise that succeeds with the result from Azure Storage
    */
-  getFileData(config, filename) {
+  getFileData(filename) {
     return new Promise((resolve, reject) => {
       this._client.getBlobToText(this._container, filename, (err, text, blob, res) => {
         if (err) {


### PR DESCRIPTION
- Adds testing based on parse-server-conformance-tests
- Adds travis scripts
- Adds coverage

We changed the adapter Api in parse-server for an upcoming release that introduces breaking changes on the files adapter.

Feel free to add 

AZURE_ACCOUNT_NAME 
AZURE_CONTAINER
AZURE_ACCESS_KEY

to travis to run the full spec.

see here: https://github.com/ParsePlatform/parse-server/pull/1172
