### PR TITLE
Updated lib after 1.0.0 release

### DIFF
--- a/lib/AzureStorageAdapter.js
+++ b/lib/AzureStorageAdapter.js
@@ -59,7 +59,7 @@ var AzureStorageAdapter = exports.AzureStorageAdapter = function () {
 
   _createClass(AzureStorageAdapter, [{
     key: 'createFile',
-    value: function createFile(config, filename, data) {
+    value: function createFile(filename, data) {
       var _this = this;
 
       var containerParams = {
@@ -92,7 +92,7 @@ var AzureStorageAdapter = exports.AzureStorageAdapter = function () {
 
   }, {
     key: 'deleteFile',
-    value: function deleteFile(config, filename) {
+    value: function deleteFile(filename) {
       var _this2 = this;
 
       return new Promise(function (resolve, reject) {
@@ -115,7 +115,7 @@ var AzureStorageAdapter = exports.AzureStorageAdapter = function () {
 
   }, {
     key: 'getFileData',
-    value: function getFileData(config, filename) {
+    value: function getFileData(filename) {
       var _this3 = this;
 
       return new Promise(function (resolve, reject) {


### PR DESCRIPTION
see #5.  The npm package will need to be updated with the new code, currently 1.0.0 is failing with parse-server@2.2.4 due to the files adapter interface change.
